### PR TITLE
Ensure maintainers are all active; add original authors for provenance

### DIFF
--- a/advanced_ml_and_api_approaches/Hyperparameter_Optimization/HyperParam_Opt_Core_Concepts.config.yaml
+++ b/advanced_ml_and_api_approaches/Hyperparameter_Optimization/HyperParam_Opt_Core_Concepts.config.yaml
@@ -4,11 +4,15 @@ description: This notebook and the functions in 'helpers.py' provide a repeatabl
 file_name: HyperParam_Opt_Core_concepts.ipynb
 languages:
   - python
-maintainers:
+authors:
   - Bogdan Tsal-Tsalko
-maintainers_email:
+authors_email:
   - bogdan.tsal-tsalko@datarobot.com
 smoke_test:
   run_smoke_test: false
+maintainers:
+  - Chandler McCann
+maintainers_email:
+  - chandler.mccann@datarobot.com
 tags: []
 title: Hyperparameter optimization workflow

--- a/advanced_ml_and_api_approaches/data_enrichment_ready_signal_ts/DataRobot_RXA.config.yaml
+++ b/advanced_ml_and_api_approaches/data_enrichment_ready_signal_ts/DataRobot_RXA.config.yaml
@@ -4,13 +4,13 @@ description: This notebook guides you through the process of using Ready Signal 
 file_name: DataRobot_RXA.ipynb
 languages:
   - python
-maintainers:
+authors:
   - Jack Claucherty
   - Jenna King
   - Baylen Springer
   - Matt Schaefer
   - Chen Wang
-maintainers_email:
+authors_email:
   - jack.claucherty@rxa.io
   - jenna.king@rxa.io
   - baylen.springer@readysignal.com
@@ -18,5 +18,9 @@ maintainers_email:
   - chen.wang@datarobot.com
 smoke_test:
   run_smoke_test: false
+maintainers:
+  - Chen Wang
+maintainers_email:
+  - chen.wang@datarobot.com
 tags: []
 title: Predict lumber prices with Ready Signal and time series forecasts

--- a/advanced_ml_and_api_approaches/parameter_tuning_with_hyperopt/Hyperparameter tuning with hyperopt.config.yaml
+++ b/advanced_ml_and_api_approaches/parameter_tuning_with_hyperopt/Hyperparameter tuning with hyperopt.config.yaml
@@ -8,6 +8,10 @@ description: This notebook builds on the hyperparameter optimizaton functionalit
 file_name: Hyperparameter tuning with hyperopt.ipynb
 languages:
   - python
+authors:
+  - Bogdan Tsal-Tsalko
+authors_email:
+  - bogdan.tsal-tsalko@datarobot.com
 maintainers:
   - Matthias Kullowatz
 maintainers_email:

--- a/advanced_ml_and_api_approaches/parameter_tuning_with_hyperopt/Hyperparameter tuning with hyperopt.config.yaml
+++ b/advanced_ml_and_api_approaches/parameter_tuning_with_hyperopt/Hyperparameter tuning with hyperopt.config.yaml
@@ -10,8 +10,10 @@ languages:
   - python
 authors:
   - Bogdan Tsal-Tsalko
+  - Matthias Kullowatz
 authors_email:
   - bogdan.tsal-tsalko@datarobot.com
+  - matthias.kullowatz@datarobot.com
 maintainers:
   - Matthias Kullowatz
 maintainers_email:

--- a/advanced_ml_and_api_approaches/parameter_tuning_with_hyperopt/Hyperparameter tuning with hyperopt.config.yaml
+++ b/advanced_ml_and_api_approaches/parameter_tuning_with_hyperopt/Hyperparameter tuning with hyperopt.config.yaml
@@ -10,10 +10,8 @@ languages:
   - python
 maintainers:
   - Matthias Kullowatz
-  - Bogdan Tsal-Tsalko
 maintainers_email:
   - matthias.kullowatz@datarobot.com
-  - bogdan.tsal-tsalko@datarobot.com
 smoke_test:
   run_smoke_test: false
 tags: []

--- a/ecosystem_integration_templates/AWS_Athena_template/AWS_Athena_End_to_End.config.yaml
+++ b/ecosystem_integration_templates/AWS_Athena_template/AWS_Athena_End_to_End.config.yaml
@@ -5,13 +5,17 @@ description: "This example notebook outlines how to read in an Amazon Athena tab
 file_name: Amazon_S3_End_to_End.ipynb
 languages:
   - python
-maintainers:
+authors:
   - Biju Krishnan
   - João Gomes
-maintainers_email:
+authors_email:
   - biju.krishnan@datarobot.com
   - joao@datarobot.com
 smoke_test:
   run_smoke_test: false
+maintainers:
+  - João Gomes
+maintainers_email:
+  - joao@datarobot.com
 tags: []
 title: DataRobot AutoML end-to-end with Amazon Athena

--- a/ecosystem_integration_templates/AWS_S3_template/Amazon_S3_End_to_End.config.yaml
+++ b/ecosystem_integration_templates/AWS_S3_template/Amazon_S3_End_to_End.config.yaml
@@ -6,13 +6,17 @@ description: "This example notebook outlines how to read in PARQUET files from a
 file_name: Amazon_S3_End_to_End.ipynb
 languages:
   - python
-maintainers:
+authors:
   - Biju Krishnan
   - João Gomes
-maintainers_email:
+authors_email:
   - biju.krishnan@datarobot.com
   - joao@datarobot.com
 smoke_test:
   run_smoke_test: false
+maintainers:
+  - João Gomes
+maintainers_email:
+  - joao@datarobot.com
 tags: []
 title: DataRobot AutoML end-to-end with Amazon Athena

--- a/ecosystem_integration_templates/Snowflake_template/Snowflake - End-to-end Ecommerce Churn.config.yaml
+++ b/ecosystem_integration_templates/Snowflake_template/Snowflake - End-to-end Ecommerce Churn.config.yaml
@@ -7,13 +7,17 @@ description: "This notebook focuses on working with Snowflake as a data source a
 file_name: Snowflake - End-to-end Ecommerce Churn.ipynb
 languages:
   - python
-maintainers:
+authors:
   - Austin Chou
   - Arjun Arora
-maintainers_email:
+authors_email:
   - austin.chou@datarobot.com
   - arjun.arora@datarobot.com
 smoke_test:
   run_smoke_test: false
+maintainers:
+  - Austin Chou
+maintainers_email:
+  - austin.chou@datarobot.com
 tags: []
 title: End-to-end modeling and production workflow with DataRobot and Snowflake

--- a/generative_ai/zero_shot_LMM_error_analysis_NLP/Zero Shot Text Classification for Error Analysis.config.yaml
+++ b/generative_ai/zero_shot_LMM_error_analysis_NLP/Zero Shot Text Classification for Error Analysis.config.yaml
@@ -4,11 +4,15 @@ description: This notebook outlines how to use zero-shot text classification wit
 file_name: Zero Shot Test Classification for Error Analysis.ipynb
 languages:
   - python
-maintainers:
+authors:
   - Glen Koundry
-maintainers_email:
+authors_email:
   - glen.koundry@datarobot.com
 smoke_test:
   run_smoke_test: false
+maintainers:
+  - Chandler McCann
+maintainers_email:
+  - chandler.mccann@datarobot.com
 tags: []
 title: Zero-shot text classification for error analysis

--- a/generative_ai/zero_shot_LMM_error_analysis_NLP/Zero Shot Text Classification for Error Analysis.config.yaml
+++ b/generative_ai/zero_shot_LMM_error_analysis_NLP/Zero Shot Text Classification for Error Analysis.config.yaml
@@ -4,15 +4,11 @@ description: This notebook outlines how to use zero-shot text classification wit
 file_name: Zero Shot Test Classification for Error Analysis.ipynb
 languages:
   - python
-authors:
-  - Glen Koundry
-authors_email:
-  - glen.koundry@datarobot.com
 smoke_test:
   run_smoke_test: false
 maintainers:
-  - Chandler McCann
+  - Glen Koundry
 maintainers_email:
-  - chandler.mccann@datarobot.com
+  - glen@datarobot.com
 tags: []
 title: Zero-shot text classification for error analysis

--- a/use_cases_and_horizontal_approaches/Demand_forecasting1_end_to_end/End_to_end_demand_forecasting.config.yaml
+++ b/use_cases_and_horizontal_approaches/Demand_forecasting1_end_to_end/End_to_end_demand_forecasting.config.yaml
@@ -5,11 +5,15 @@ description: "This notebook illustrates an end-to-end demand forecasting workflo
 file_name: End_to_end_demand_forecasting.py
 languages:
   - python
-maintainers:
+authors:
   - Andrii Kruchko
-maintainers_email:
+authors_email:
   - andrii.kruchko@datarobot.com
 smoke_test:
   run_smoke_test: false
+maintainers:
+  - Chandler McCann
+maintainers_email:
+  - chandler.mccann@datarobot.com
 tags: []
 title: End-to-end demand forecasting workflow

--- a/use_cases_and_horizontal_approaches/Demand_forecasting2_cold_start/End_to_end_demand_forecasting_cold_start.config.yaml
+++ b/use_cases_and_horizontal_approaches/Demand_forecasting2_cold_start/End_to_end_demand_forecasting_cold_start.config.yaml
@@ -5,11 +5,15 @@ description: "This notebook illustrates an end-to-end demand forecasting workflo
 file_name: End_to_end_demand_forecasting_cold_start.ipynb
 languages:
   - python
-maintainers:
+authors:
   - Andrii Kruchko
-maintainers_email:
+authors_email:
   - andrii.kruchko@datarobot.com
 smoke_test:
   run_smoke_test: false
+maintainers:
+  - Chandler McCann
+maintainers_email:
+  - chandler.mccann@datarobot.com
 tags: []
 title: 'End-to-end demand forecasting: cold start predictions'

--- a/use_cases_and_horizontal_approaches/Demand_forecasting3_retraining/End_to_end_demand_forecasting_retraining.config.yaml
+++ b/use_cases_and_horizontal_approaches/Demand_forecasting3_retraining/End_to_end_demand_forecasting_retraining.config.yaml
@@ -5,11 +5,15 @@ description: "This notebook illustrates an end-to-end demand forecasting workflo
 file_name: End_to_end_demand_forecasting_retraining.ipynb
 languages:
   - python
-maintainers:
+authors:
   - Andrii Kruchko
-maintainers_email:
+authors_email:
   - andrii.kruchko@datarobot.com
 smoke_test:
   run_smoke_test: false
+maintainers:
+  - Chandler McCann
+maintainers_email:
+  - chandler.mccann@datarobot.com
 tags: []
 title: End-to-end demand forecasting and retraining workflow

--- a/use_cases_and_horizontal_approaches/Demand_forecasting4_what_if_app/demand_forecasting_app.config.yaml
+++ b/use_cases_and_horizontal_approaches/Demand_forecasting4_what_if_app/demand_forecasting_app.config.yaml
@@ -4,11 +4,15 @@ description: This demand forecasting what-if app allows you to adjust certain kn
 file_name: demand_forecasting_app.py
 languages:
   - python
-maintainers:
+authors:
   - Andrii Kruchko
-maintainers_email:
+authors_email:
   - andrii.kruchko@datarobot.com
 smoke_test:
   run_smoke_test: false
+maintainers:
+  - Chandler McCann
+maintainers_email:
+  - chandler.mccann@datarobot.com
 tags: []
 title: Create a demand forecasting What-If app

--- a/use_cases_and_horizontal_approaches/healthcare_appointment_no_show_prediction/no_show.config.yaml
+++ b/use_cases_and_horizontal_approaches/healthcare_appointment_no_show_prediction/no_show.config.yaml
@@ -12,11 +12,15 @@ description: "Many people are guilty of having canceled a doctor’s appointment
 file_name: End-to-end Automated Feature Discovery Production Workflow.ipynb
 languages:
   - python
-maintainers:
+authors:
   - Joseph Blue
-maintainers_email:
+authors_email:
   - joseph.blue@datarobot.com
 smoke_test:
   run_smoke_test: false
+maintainers:
+  - Chandler McCann
+maintainers_email:
+  - chandler.mccann@datarobot.com
 tags: []
 title: End-to-end Automated Feature Discovery Production Workflow


### PR DESCRIPTION
In this PR I've updated the configs for a number of accelerators to ensure that the `maintainers` with `maintainers_emails` represent active developers. For provenance and attribution, I've added optional `authors` and `authors_emails` fields with the original accelerator authors.

In any case where one of the previous "maintainers" is still an active developer, I've re-listed them as the sole maintainers and moved the rest under "authors".

In any case where none of the previous "maintainers" are active, I've moved them under "authors" and listed Chandler M as the sole maintainer. Accelerators written by Bogdan T-T, Joseph B, ~~and Glen K~~ are examples.

@jpgomes @cmccann11 @austinchou-dr if you'd like to review these, we can make updates in this PR or in follow ups.