### PR TITLE
setting one accelerator to not run smoke tests yet

### DIFF
--- a/ecosystem_integration_templates/Custom Model End-to-End With Compliance Docs/Custom Model End-to-End With Compliance Docs.config.yaml
+++ b/ecosystem_integration_templates/Custom Model End-to-End With Compliance Docs/Custom Model End-to-End With Compliance Docs.config.yaml
@@ -10,7 +10,7 @@ maintainers:
 maintainers_email:
   - luke.shulman@datarobot.com
 smoke_test:
-  run_smoke_test: true
+  run_smoke_test: false
   user_permissions:
     - ENABLE_PUBLIC_NETWORK_ACCESS_FOR_ALL_CUSTOM_MODELS
 tags: []


### PR DESCRIPTION
We had one last accelerator set to run smoke tests before it was ready.