### PR TITLE
Fixes OpenAI template type error, makes compatible with playground

### DIFF
--- a/generative_ai/LLM_custom_inference_model_template/storage/templates/openai/custom.py
+++ b/generative_ai/LLM_custom_inference_model_template/storage/templates/openai/custom.py
@@ -1,9 +1,9 @@
+from typing import Iterator
 from datarobot_drum import RuntimeParameters
 from openai import OpenAI
 from openai.types.chat import ChatCompletion, ChatCompletionChunk, CompletionCreateParams
 import pandas as pd
 import os
-
 
 def load_model(*args, **kwargs)-> OpenAI:
     if (env_key := os.getenv("open_api_key")):
@@ -35,7 +35,7 @@ def score(data: pd.DataFrame, model, **kwargs):
 
     for prompt in prompts:
         response = model.chat.completions.create(
-            model="gpt-4",
+            model=RuntimeParameters.get("MODEL"),
             messages=[
                 {"role": "user", "content": f"{prompt}"},
             ],
@@ -61,4 +61,6 @@ def chat(completion_create_params: CompletionCreateParams, model: OpenAI)-> Chat
     ChatCompletion
         the completion object with generated choices. 
     """
+    if completion_create_params['model'] == "datarobot-deployed-llm":
+        completion_create_params['model'] = RuntimeParameters.get("MODEL")
     return model.chat.completions.create(**completion_create_params)

--- a/generative_ai/LLM_custom_inference_model_template/storage/templates/openai/model-metadata.yaml
+++ b/generative_ai/LLM_custom_inference_model_template/storage/templates/openai/model-metadata.yaml
@@ -10,3 +10,6 @@ runtimeParameterDefinitions:
   - fieldName: PROMPT_COLUMN_NAME
     type: string
     defaultValue: promptText
+  - fieldName: MODEL
+    type: string
+    defaultValue: gpt-4o-mini


### PR DESCRIPTION
The model errors without the typing import.

Also, we need to provide a valid model name to use the model in the playground. This provides a default model name that can be changed with a runtime parameter.

When being called live, the model name can be adjusted. Or the default can be used by calling the completion with model == "datarobot-deployed-llm".