### PR TITLE
DOC-9294: Agent accelerator fix

### DIFF
--- a/generative_ai/adaptive-agent/agent/pyproject.toml
+++ b/generative_ai/adaptive-agent/agent/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "datarobot-drum>=1.17.5,<1.18.0",
     "datarobot-mlops>=11.1.0",
     "openai>=1.81.0,<2.0.0",
-    "litellm>=1.72.1,<2.0.0",
+    "litellm>=1.72.1,!=1.82.7,!=1.82.8",
     "langchain-litellm>=0.2.3",
     "opentelemetry-api>=1.33.0,<2.0.0",
     "opentelemetry-sdk>=1.33.0,<2.0.0",

--- a/generative_ai/adaptive-agent/infra/pyproject.toml
+++ b/generative_ai/adaptive-agent/infra/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.11, <3.14"
 dependencies = [
     "datarobot>=3.8.2",
     "datarobot-pulumi-utils>=0.1.0",
-    "litellm>=1.72.1",
+    "litellm>=1.72.1,!=1.82.7,!=1.82.8",
     "pulumi>=3.175.0",
     "pulumi-datarobot>=0.10.27",
     "jinja2>=3.1.5,<4.0",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk dependency-only change; main impact is on install/lock resolution for projects that would otherwise pull `litellm` 1.82.7/1.82.8.
> 
> **Overview**
> Pins `litellm` in both `agent` and `infra` `pyproject.toml` to **exclude** versions `1.82.7` and `1.82.8` while keeping the existing minimum version, preventing these releases from being selected during dependency resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a079bf46ccb631895952bc8e881047f32a573c01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->