### PR TITLE
update to static dataset and refresh date ranges

### DIFF
--- a/use_cases_and_horizontal_approaches/model_factory_selfjoin_fantasy_baseball/fantasy_baseball_predictions_model_factory.ipynb
+++ b/use_cases_and_horizontal_approaches/model_factory_selfjoin_fantasy_baseball/fantasy_baseball_predictions_model_factory.ipynb
@@ -474,8 +474,10 @@
     "\n",
     "    return df\n",
     "\n",
-    "\n",
-    "batters_training = data_prep(batters_training)"
+    "# using a static dataset for reproducibility \n",
+    "batters_training_data = pd.read_csv(\"https://s3.us-east-1.amazonaws.com/datarobot_public_datasets/ai_accelerators/batters_training_data_raw.csv\")\n",
+    "batters_training_data = data_prep(batters_training_data) # data until 2025\n",
+    "batters_training = batters_training_data.loc[batters_training_data['Season'] < 2025,]"
    ]
   },
   {
@@ -1104,11 +1106,14 @@
     }
    ],
    "source": [
-    "# scoring_data = batters_training[batters_training['Season' == 2023]].copy()\n",
-    "scoring_data = batting_stats(2023, 2023, qual=1)\n",
+    "#scoring_data = batting_stats(2023, 2023, qual=1)\n",
     "\n",
     "# Prep the data with our function from above\n",
-    "scoring_data = data_prep(scoring_data)\n",
+    "#scoring_data = data_prep(scoring_data)\n",
+    "\n",
+    "# using a static dataset for reproducibility \n",
+    "# scoring_data = batters_training[batters_training['Season' == 2023]].copy()\n",
+    "scoring_data = batters_training_data.loc[batters_training_data['Season'] == 2025,]\n",
     "scoring_data.to_csv(f\"AVG_scoring_data_{datetime.today()}.csv\")\n",
     "scoring_data.head()"
    ]
@@ -1127,8 +1132,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "new_secondary_df = batting_stats(2020, 2022, qual=1)\n",
-    "new_secondary_df = data_prep(new_secondary_df)\n",
+    "#new_secondary_df = batting_stats(2020, 2022, qual=1)\n",
+    "#new_secondary_df = data_prep(new_secondary_df)\n",
+    "\n",
+    "new_secondary_df = batters_training_data.loc[batters_training_data['Season'].between(2022,2025, inclusive='left'),]\n",
     "# Overwrite the prior secondary dataset, both the Python object and in the AI Catalog\n",
     "secondary_dataset_object = dr.Dataset.create_version_from_in_memory_data(\n",
     "    dataset_id=secondary_dataset_object.id,\n",
@@ -1640,7 +1647,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1654,7 +1661,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
update to static dataset and refresh date ranges

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Notebook-only reproducibility and date-window changes; no production services, auth, or data-pipeline code.
> 
> **Overview**
> The fantasy baseball model-factory notebook **stops using in-memory/live `batting_stats` output** for the main training path after `data_prep`. It **loads a fixed CSV from DataRobot’s public S3** (`batters_training_data_raw.csv`), prepares it, and sets **`batters_training` to seasons before 2025**.
> 
> **Scoring** no longer fetches 2023 stats from the API; it **takes the 2025 season slice** from that same static prepared frame (live `batting_stats` / `data_prep` calls are commented out).
> 
> **Secondary dataset refresh** for predictions similarly **drops the 2020–2022 API pull** and **builds `new_secondary_df` from seasons 2022–2024** (`between(2022, 2025, inclusive='left')`) on the static data.
> 
> Notebook metadata only: **kernelspec** label **Python 3 (ipykernel)** and **language version 3.10.12** (was 3.8.8).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34d542a3114999c1e50a3ec0e74423cf1e0a9958. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->